### PR TITLE
Use reflection to make PersonAppearances encodable as CSV, XLSX and XLS

### DIFF
--- a/linklives-lib/Domain/PersonAppearance/BasePA.cs
+++ b/linklives-lib/Domain/PersonAppearance/BasePA.cs
@@ -3,9 +3,8 @@ using Nest;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Resources;
-using System.Text;
 using System.Text.RegularExpressions;
+using Linklives.Serialization;
 
 namespace Linklives.Domain
 {
@@ -15,12 +14,18 @@ namespace Linklives.Domain
     [ElasticsearchType(IdProperty = nameof(Key))]
     public class BasePA : SortableItem
     {
+        [Exportable(FieldCategory.Identification)]
         public int Source_id { get; set; }
+
+        [Exportable(FieldCategory.Identification)]
         public int Pa_id { get; set; }
+
+        [Exportable(FieldCategory.Standard)]
         public SourceType Type { get; protected set; }
 
         //Searchables
         private string _name_searchable;
+        [Exportable(FieldCategory.Standard)]
         public string Name_searchable
         {
             set

--- a/linklives-lib/Domain/PersonAppearance/BasePA.cs
+++ b/linklives-lib/Domain/PersonAppearance/BasePA.cs
@@ -20,12 +20,11 @@ namespace Linklives.Domain
         [Exportable(FieldCategory.Identification)]
         public int Pa_id { get; set; }
 
-        [Exportable(FieldCategory.Standard)]
+        [Exportable(FieldCategory.Identification)]
         public SourceType Type { get; protected set; }
 
         //Searchables
         private string _name_searchable;
-        [Exportable(FieldCategory.Standard)]
         public string Name_searchable
         {
             set
@@ -57,7 +56,6 @@ namespace Linklives.Domain
             }
         }
         private string _lastname_searchable;
-        [Exportable(FieldCategory.Standard)]
         public string Lastname_searchable
         {
             set
@@ -96,7 +94,6 @@ namespace Linklives.Domain
             }
         }
         private string _firstnames_searchable;
-        [Exportable(FieldCategory.Standard)]
         public string Firstnames_searchable
         {
             set
@@ -448,11 +445,13 @@ namespace Linklives.Domain
         /// <summary>
         /// The original standardised Person Appearance data
         /// </summary>
+        [NestedExportable("st_", extraWeight: 1000, includeAllProperties: true)]
         public StandardPA Standard { get; set; }
         /// <summary>
         /// The raw transcribed Person Appearance data
         /// </summary>
         [Nest.Ignore] //Tells nest to ignore the property when indexing but still lets us include it when serializing to json
+        [NestedExportable("tr_", extraWeight: 2000, includeAllProperties: true)]
         public TranscribedPA Transcribed { get; set; }
         [Nest.Ignore]
         public Source Source { get; set; }

--- a/linklives-lib/Domain/PersonAppearance/BasePA.cs
+++ b/linklives-lib/Domain/PersonAppearance/BasePA.cs
@@ -57,6 +57,7 @@ namespace Linklives.Domain
             }
         }
         private string _lastname_searchable;
+        [Exportable(FieldCategory.Standard)]
         public string Lastname_searchable
         {
             set
@@ -95,6 +96,7 @@ namespace Linklives.Domain
             }
         }
         private string _firstnames_searchable;
+        [Exportable(FieldCategory.Standard)]
         public string Firstnames_searchable
         {
             set

--- a/linklives-lib/Serialization/Encoder.cs
+++ b/linklives-lib/Serialization/Encoder.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Linklives.Serialization {
+public abstract class Encoder {
+    public static Encoder ForFormat(string format) {
+        if(format == "xlsx") {
+            return XlsxEncoder.Instance;
+        }
+        if(format == "csv") {
+            return CsvEncoder.Instance;
+        }
+        if(format == "xls") {
+            return XlsEncoder.Instance;
+        }
+        return null;
+    }
+
+    public abstract string ContentType {
+        get;
+    }
+
+    public abstract MemoryStream Encode(Dictionary<string, string>[] rows);
+
+    protected Dictionary<string, int> GetColumnKeys(Dictionary<string, string>[] rows) {
+        // TODO: maybe a default ordering we strip things from that are not in any rows?
+        var result = new Dictionary<string, int>();
+        foreach(var row in rows) {
+            foreach(var key in row.Keys) {
+                if(!result.ContainsKey(key)) {
+                    result[key] = result.Count;
+                }
+            }
+        }
+        return result;
+    }
+
+    protected string[] GetOrderedColumns(Dictionary<string, int> columnMap) {
+        // Use the columnMap values to order the results
+        return columnMap.Keys
+            .OrderBy((key) => columnMap[key])
+            .ToArray();
+    }
+
+    protected string[] GetOrderedValues(Dictionary<string, int> columnMap, Dictionary<string, string> row) {
+        // The result will be the length of the columnMap
+        var result = new string[columnMap.Count];
+
+        // Map each key to its position in the result using the columnMap as lookup
+        foreach(var key in row.Keys) {
+            var i = columnMap[key];
+            result[i] = row[key];
+        }
+        return result;
+    }
+}
+
+public class XlsxEncoder: Encoder {
+    private static XlsxEncoder instance = new XlsxEncoder();
+    public static XlsxEncoder Instance {
+        get {
+            return instance;
+        }
+    }
+
+    public override string ContentType {
+        get {
+            return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        }
+    }
+
+    public override MemoryStream Encode(Dictionary<string, string>[] rows)
+    {
+        // Write to Workbook
+        var workbook = new NPOI.XSSF.UserModel.XSSFWorkbook();
+        var sheet = workbook.CreateSheet("Link-lives Download");
+
+        var columnMap = GetColumnKeys(rows);
+        var orderedColumns = GetOrderedColumns(columnMap);
+
+        var headerRow = sheet.CreateRow(0);
+        for (var i = 0; i < orderedColumns.Length; i++) {
+            var cell = headerRow.CreateCell(i);
+            cell.SetCellValue(orderedColumns[i]);
+        }
+
+        for (var i = 0; i < rows.Length; i++) {
+            var row = rows[i];
+            var orderedValues = GetOrderedValues(columnMap, row);
+            var sheetRow = sheet.CreateRow(i + 1);
+
+            for (var j = 0; j < orderedValues.Length; j++) {
+                var cell = sheetRow.CreateCell(j);
+                cell.SetCellValue(orderedValues[j]);
+            }
+        }
+
+        // Output to stream - NPOI closes a memory stream on write, so we need to discard one (so weird tbh)
+        var intermediate = new MemoryStream();
+        workbook.Write(intermediate);
+        var bytes = intermediate.ToArray();
+
+        return new MemoryStream(bytes);
+    }
+}
+
+public class XlsEncoder: Encoder {
+    private static XlsEncoder instance = new XlsEncoder();
+    public static XlsEncoder Instance {
+        get {
+            return instance;
+        }
+    }
+
+    public override string ContentType {
+        get {
+            return "application/vnd.ms-excel";
+        }
+    }
+
+    public override MemoryStream Encode(Dictionary<string, string>[] rows)
+    {
+        // Write to Workbook
+        var workbook = new CarlosAg.ExcelXmlWriter.Workbook();
+        var sheet = workbook.Worksheets.Add("Link-lives Download");
+
+        var columnMap = GetColumnKeys(rows);
+        var orderedColumns = GetOrderedColumns(columnMap);
+
+        var headingRow = sheet.Table.Rows.Add();
+        foreach(var col in orderedColumns) {
+            headingRow.Cells.Add(col);
+        }
+
+        foreach(var row in rows) {
+            var orderedValues = GetOrderedValues(columnMap, row);
+            var sheetRow = sheet.Table.Rows.Add();
+
+            foreach(var val in orderedValues) {
+                sheetRow.Cells.Add(val ?? "");
+            }
+        }
+
+        // Output to stream via temp file
+        var result = new MemoryStream();
+        var tempFilePath = Path.GetTempFileName();
+        try {
+            workbook.Save(tempFilePath);
+
+            using (var readingFileStream = File.OpenRead(tempFilePath)) {
+                readingFileStream.CopyTo(result);
+            }
+        }
+        finally {
+            File.Delete(tempFilePath);
+        }
+
+        //result.Seek(0, SeekOrigin.Begin); // Needed?
+
+        return result;
+    }
+}
+
+public class CsvEncoder: Encoder {
+    private static CsvEncoder instance = new CsvEncoder();
+    public static CsvEncoder Instance {
+        get {
+            return instance;
+        }
+    }
+
+    public override string ContentType {
+        get {
+            return "text/csv";
+        }
+    }
+
+    public override MemoryStream Encode(Dictionary<string, string>[] rows) {
+        var result = new StringBuilder();
+
+        var columnMap = GetColumnKeys(rows);
+        var orderedColumns = GetOrderedColumns(columnMap);
+        WriteRow(result, orderedColumns);
+
+        foreach(var row in rows) {
+            var orderedValues = GetOrderedValues(columnMap, row);
+            WriteRow(result, orderedValues);
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(result.ToString());
+        return new MemoryStream(bytes);
+    }
+
+    private Regex quotesRegex = new Regex("\"");
+
+    private void WriteRow(StringBuilder result, IEnumerable<string> items) {
+        items = items.Select((item) => {
+            if(item == null) {
+                return "";
+            }
+            if(!item.Contains(",") && !item.Contains("\"") && !item.Contains("\n")) {
+                return item;
+            }
+            return $"\"{quotesRegex.Replace(item, "\"\"")}\"";
+        });
+
+        result.Append(string.Join(",", items));
+        result.Append("\n");
+    }
+}
+}

--- a/linklives-lib/Serialization/SpreadsheetSerializer.cs
+++ b/linklives-lib/Serialization/SpreadsheetSerializer.cs
@@ -62,8 +62,4 @@ public enum FieldCategory {
     Transcribed = 500,
     Other = 999,
 }
-
-public interface RowSerializable {
-    Dictionary<string, string>[] Serialize();
-}
 }

--- a/linklives-lib/Serialization/SpreadsheetSerializer.cs
+++ b/linklives-lib/Serialization/SpreadsheetSerializer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 
 namespace Linklives.Serialization {
 public static class SpreadsheetSerializer {
@@ -10,24 +11,102 @@ public static class SpreadsheetSerializer {
         return items.SelectMany((item) => Serialize(item)).ToArray();
     }
 
-    public static Dictionary<string, (string, Exportable)>[] Serialize(object item) {
-        var result = new Dictionary<string,(string, Exportable)>{};
-
+    public static Dictionary<string, (string, Exportable)>[] Serialize(object item, NestedExportable parent = null) {
         var serializableProperties = item.GetType().GetProperties()
             .Where((prop) => prop.CanRead)
             .Select((prop) => {
                 var attrs = prop.GetCustomAttributes(true);
-                var exportableAttr = (Exportable)attrs.FirstOrDefault((attr) => attr is Exportable);
+                var exportableAttr = attrs.FirstOrDefault((attr) => attr is Exportable || attr is NestedExportable);
+
+                if(parent != null) {
+                    if(parent.IncludeAllProperties && exportableAttr == null) {
+                        exportableAttr = new Exportable(FieldCategory.Other, parent.Prefix, parent.ExtraWeight);
+                    }
+                    else if(exportableAttr is Exportable) {
+                        exportableAttr = ((Exportable)exportableAttr).Expand(parent.Prefix, parent.ExtraWeight);
+                    }
+                }
+
                 return (prop, exportableAttr);
             })
             .Where((propAttrPair) => propAttrPair.Item2 != null);
 
-        foreach(var (prop, attr) in serializableProperties) {
+        var flatFields = serializableProperties
+            .Where((propAttrPair) => {
+                var (prop, attr) = propAttrPair;
+                return attr is Exportable;
+            })
+            .Select((propAttrPair) => {
+                var (prop, attr) = propAttrPair;
+                return (prop, (Exportable)attr);
+            });
+
+        var flatFieldsRow = new Dictionary<string,(string, Exportable)>{};
+        foreach(var (prop, attr) in flatFields) {
             var value = prop.GetValue(item, null);
-            result[attr.BuildName(prop.Name)] = (value?.ToString(), attr);
+            flatFieldsRow[attr.BuildName(prop.Name)] = (value?.ToString(), attr);
+            continue;
         }
 
-        return new [] { result };
+        var nestedListFieldRows = serializableProperties
+            .Where((propAttrPair) => {
+                var (prop, attr) = propAttrPair;
+                return attr is NestedExportable;
+            })
+            .Select((propAttrPair) => {
+                var (prop, attr) = propAttrPair;
+                var nestedExportable = (NestedExportable)attr;
+                var value = prop.GetValue(item, null);
+                if(value == null) {
+                    return new Dictionary<string,(string, Exportable)>[] {};
+                }
+
+                if(typeof(IEnumerable<object>).IsAssignableFrom(prop.PropertyType)) {
+                    var enumerable = (IEnumerable<object>)value;
+                    return enumerable.SelectMany((item, i) => Serialize(item, nestedExportable.Expand(extraWeight: i)));
+                }
+
+                return Serialize(value, nestedExportable);
+            });
+        
+        var nestedListFieldRowsArray = nestedListFieldRows.ToArray();
+        var flatFieldsRows = new [] { flatFieldsRow };
+        if(nestedListFieldRowsArray.Length == 0) {
+            return flatFieldsRows;
+        }
+
+        var listOfRowsOfRows = new IEnumerable<Dictionary<string, (string, Exportable)>>[nestedListFieldRowsArray.Length + 1];
+        listOfRowsOfRows[0] = flatFieldsRows;
+        for(var i = 0; i < nestedListFieldRowsArray.Length; i++) {
+            listOfRowsOfRows[i + 1] = nestedListFieldRowsArray[i];
+        }
+        return BraidRows(listOfRowsOfRows);
+    }
+
+    private static Dictionary<string, (string, Exportable)>[] BraidRows(IEnumerable<Dictionary<string, (string, Exportable)>>[] listOfRowsOfRows) {
+        var firstColSet = listOfRowsOfRows[0];
+        var secondColSet = listOfRowsOfRows[1];
+
+        var resultRows = new List<Dictionary<string, (string, Exportable)>>();
+        foreach(var firstColSetRow in firstColSet) {
+            foreach(var secondColSetRow in secondColSet) {
+                var resultRow = new Dictionary<string, (string, Exportable)>();
+                foreach(var (k, v) in firstColSetRow) {
+                    resultRow[k] = v;
+                }
+                foreach(var (k, v) in secondColSetRow) {
+                    resultRow[k] = v;
+                }
+                resultRows.Add(resultRow);
+            }
+        }
+
+        if(listOfRowsOfRows.Length == 2) {
+            return resultRows.ToArray();
+        }
+
+        var result = listOfRowsOfRows.Skip(2).Prepend(resultRows);
+        return BraidRows(result.ToArray());
     }
 }
 
@@ -35,21 +114,24 @@ public static class SpreadsheetSerializer {
 public class Exportable : Attribute {
     private FieldCategory _cat;
     private string _prefix;
+    private int _extraWeight;
 
-    public Exportable(FieldCategory cat = FieldCategory.Other, string prefix = "") {
+    public Exportable(FieldCategory cat = FieldCategory.Other, string prefix = "", int extraWeight = 0) {
         this._cat = cat;
         this._prefix = prefix;
+        this._extraWeight = extraWeight;
+    }
+
+    public Exportable Expand(string prefix = "", int extraWeight = 0) {
+        return new Exportable(
+            _cat,
+            prefix + _prefix,
+            extraWeight + _extraWeight
+        );
     }
 
     public string BuildName(string name) {
         var sb = new StringBuilder();
-
-        if(_cat is FieldCategory.Standard) {
-            sb.Append("st_");
-        }
-        else if(_cat is FieldCategory.Transcribed) {
-            sb.Append("tr_");
-        }
 
         sb.Append(_prefix);
         sb.Append(name);
@@ -59,15 +141,39 @@ public class Exportable : Attribute {
 
     public int Weight {
         get {
-            return (int)this._cat;
+            return _extraWeight + (int)this._cat;
         }
+    }
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public class NestedExportable : Attribute {
+    string _prefix;
+    public string Prefix { get { return _prefix; } }
+
+    int _extraWeight;
+    public int ExtraWeight { get { return _extraWeight; } }
+
+    bool _includeAllProperties;
+    public bool IncludeAllProperties { get { return _includeAllProperties; } }
+
+    public NestedExportable(string prefix = "", int extraWeight = 1000, bool includeAllProperties = false) {
+        _prefix = prefix;
+        _extraWeight = extraWeight;
+        _includeAllProperties = includeAllProperties;
+    }
+
+    public NestedExportable Expand(int extraWeight = 0) {
+        return new NestedExportable(
+            _prefix,
+            _extraWeight + extraWeight,
+            _includeAllProperties
+        );
     }
 }
 
 public enum FieldCategory {
     Identification = 100,
-    Standard = 300,
-    Transcribed = 500,
-    Other = 999,
+    Other = 900,
 }
 }

--- a/linklives-lib/Serialization/SpreadsheetSerializer.cs
+++ b/linklives-lib/Serialization/SpreadsheetSerializer.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Linklives.Serialization {
+public static class SpreadsheetSerializer {
+    public static Dictionary<string, string>[] Serialize(object[] items) {
+        Dictionary<string, string> result = new Dictionary<string, string>();
+        return items.SelectMany((item) => Serialize(item)).ToArray();
+    }
+
+    public static Dictionary<string, string>[] Serialize(object item) {
+        var result = new Dictionary<string,string>{};
+
+        var serializableProperties = item.GetType().GetProperties()
+            .Where((prop) => prop.CanRead)
+            .Where((prop) => {
+                var attrs = prop.GetCustomAttributes(true);
+                return attrs.Any((attr) => attr is Exportable);
+            });
+
+        foreach(var prop in serializableProperties) {
+            var value = prop.GetValue(item, null);
+            result[prop.Name.ToLower()] = value?.ToString();
+        }
+
+        return new [] { result };
+    }
+}
+
+[AttributeUsage(AttributeTargets.Property)]
+public class Exportable : Attribute {
+    private FieldCategory _cat;
+    private string _prefix;
+
+    public Exportable(FieldCategory cat = FieldCategory.Other, string prefix = "") {
+        this._cat = cat;
+        this._prefix = prefix;
+    }
+
+    public string BuildName(string name) {
+        var sb = new StringBuilder();
+
+        if(_cat is FieldCategory.Standard) {
+            sb.Append("st_");
+        }
+        else if(_cat is FieldCategory.Transcribed) {
+            sb.Append("tr_");
+        }
+
+        sb.Append(_prefix);
+        sb.Append(name);
+
+        return sb.ToString();
+    }
+}
+
+public enum FieldCategory {
+    Identification = 100,
+    Standard = 300,
+    Transcribed = 500,
+    Other = 999,
+}
+
+public interface RowSerializable {
+    Dictionary<string, string>[] Serialize();
+}
+}

--- a/linklives-lib/linklives-lib.csproj
+++ b/linklives-lib/linklives-lib.csproj
@@ -14,16 +14,16 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Version>2.0.7986.15318</Version>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="27.1.1" />
-    <PackageReference Include="MySql.EntityFrameworkCore" Version="5.0.5" />
-    <PackageReference Include="NEST" Version="7.15.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="5.2.15" />
+    <PackageReference Include="CsvHelper" Version="27.1.1"/>
+    <PackageReference Include="MySql.EntityFrameworkCore" Version="5.0.5"/>
+    <PackageReference Include="NEST" Version="7.15.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
+    <PackageReference Include="Z.EntityFramework.Extensions.EFCore" Version="5.2.15"/>
+    <PackageReference Include="CarlosAgExcelXmlWriterLibrary" Version="1.0.0"/>
+    <PackageReference Include="NPOI" Version="2.6.0.1"/>
   </ItemGroup>
-
   <ItemGroup>
     <Compile Update="Resources\PAStrings.Designer.cs">
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
This PR adds support for serialization through reflection of data types into a row-based format. It also adds encoders that can encode such rows into commonly used spreadsheet formats.

This will be used in linklives-api to expose a /download endpoint that allows the downloading of data.