### PR TITLE
Iterate on exported fields

### DIFF
--- a/linklives-lib/Domain/KeyedItem.cs
+++ b/linklives-lib/Domain/KeyedItem.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
+using Linklives.Serialization;
+using Linklives.Domain;
 
 namespace Linklives.Domain
 {
@@ -18,6 +20,7 @@ namespace Linklives.Domain
         public bool Is_historic { get; set; }
         [Nest.Keyword]
         [CsvHelper.Configuration.Attributes.Ignore]
+        [Exportable(FieldCategory.Identification, exportIfType: typeof(LifeCourse))]
         public string Data_version { get; set; }
         public abstract void InitKey();
     }

--- a/linklives-lib/Domain/Lifecourse/LifeCourse.cs
+++ b/linklives-lib/Domain/Lifecourse/LifeCourse.cs
@@ -21,7 +21,6 @@ namespace Linklives.Domain
         [Name("pa_ids")]
         public string Pa_ids { get; set; }
         [Name("source_ids")]
-        [Exportable(FieldCategory.Identification)]
         public string Source_ids { get; set; }
         [Name("link_ids")]
         public string Link_ids { get; set; }

--- a/linklives-lib/Domain/PersonAppearance/BasePA.cs
+++ b/linklives-lib/Domain/PersonAppearance/BasePA.cs
@@ -451,7 +451,7 @@ namespace Linklives.Domain
         /// The raw transcribed Person Appearance data
         /// </summary>
         [Nest.Ignore] //Tells nest to ignore the property when indexing but still lets us include it when serializing to json
-        [NestedExportable("tr_", extraWeight: 2000, includeAllProperties: true)]
+        [NestedExportable("tr_", extraWeight: 2000)]
         public TranscribedPA Transcribed { get; set; }
         [Nest.Ignore]
         public Source Source { get; set; }

--- a/linklives-lib/Domain/PersonAppearance/TranscribedPA.cs
+++ b/linklives-lib/Domain/PersonAppearance/TranscribedPA.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.Text;
+using Linklives.Serialization;
 
 namespace Linklives.Domain
 {
@@ -14,6 +14,8 @@ namespace Linklives.Domain
         private TranscriptionType transcriptionType;
         public int Pa_id { get; set; }
         public int Source_id { get; set; }
+
+        [NestedExportable()]
         public dynamic Transcription { get; set; }
         public TranscribedPA()
         {

--- a/linklives-lib/Serialization/SpreadsheetSerializer.cs
+++ b/linklives-lib/Serialization/SpreadsheetSerializer.cs
@@ -103,8 +103,18 @@ public static class SpreadsheetSerializer {
     }
 
     private static Dictionary<string, (string, Exportable)>[] BraidRows(IEnumerable<Dictionary<string, (string, Exportable)>>[] listOfRowsOfRows) {
+        if(listOfRowsOfRows.Length == 1) {
+            return listOfRowsOfRows[0].ToArray();
+        }
+
         var firstColSet = listOfRowsOfRows[0];
+        if(firstColSet.Count() == 0) {
+            return BraidRows(listOfRowsOfRows.Skip(1).ToArray());
+        }
         var secondColSet = listOfRowsOfRows[1];
+        if(secondColSet.Count() == 0) {
+            return BraidRows(listOfRowsOfRows.Skip(2).Prepend(firstColSet).ToArray());
+        }
 
         var resultRows = new List<Dictionary<string, (string, Exportable)>>();
         foreach(var firstColSetRow in firstColSet) {


### PR DESCRIPTION
Changes to exports:

- Include lifecourse data_version field
- No longer export source_ids on lifecourses, as source_id  on personappearances covers the same info
- Inline the transcription field's contents as individual columns