### PR TITLE
When using forced Inline nesting strategy, skip indexers

### DIFF
--- a/linklives-lib/Serialization/SpreadsheetSerializer.cs
+++ b/linklives-lib/Serialization/SpreadsheetSerializer.cs
@@ -90,7 +90,7 @@ public static class SpreadsheetSerializer {
 
                 // Key-value dynamic object should be inlined if nestedExpandable.ForcedStrategy == NestingStrategy.Inline
                 if(nestedExportable.ForcedStrategy == NestingStrategy.Inline) {
-                    var props = value.GetType().GetProperties().Where((nestedProp) => nestedProp.CanRead);
+                    var props = value.GetType().GetProperties().Where((nestedProp) => nestedProp.CanRead && nestedProp.GetIndexParameters().Length == 0);
                     var result = new Dictionary<string, (string, Exportable)> {};
                     foreach(var nestedProp in props) {
                         var propAttr = new Exportable(prefix: nestedExportable.Prefix, extraWeight: nestedExportable.ExtraWeight);


### PR DESCRIPTION
Indexers on the type are not easily inlined, so we skip for now.